### PR TITLE
Implementing IntoIterator & Extend

### DIFF
--- a/src/extend.rs
+++ b/src/extend.rs
@@ -8,3 +8,30 @@ impl<T, const N: usize> Extend<T> for LocalVec<T, N> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extend() {
+        let mut vec = LocalVec::<_, 4>::new();
+        let arr = [1, 2, 3, 4];
+        vec.extend(arr);
+
+        matches!(vec.pop(), Some(4));
+        matches!(vec.pop(), Some(3));
+        matches!(vec.pop(), Some(2));
+        matches!(vec.pop(), Some(1));
+        matches!(vec.pop(), None);
+    }
+
+
+    #[test]
+    #[should_panic]
+    fn test_extend_exceeding() {
+        let mut vec = LocalVec::<_, 3>::new();
+        let arr = [1, 2, 3, 4];
+        vec.extend(arr);
+    }
+}

--- a/src/extend.rs
+++ b/src/extend.rs
@@ -1,0 +1,10 @@
+use crate::LocalVec;
+use std::iter::Extend;
+
+impl<T, const N: usize> Extend<T> for LocalVec<T, N> {
+    fn extend<I: IntoIterator<Item=T>>(&mut self, iter: I) {
+        for elem in iter {
+            self.push(elem);
+        }
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -27,10 +27,3 @@ impl<T, const N: usize> Iterator for LocalVecIter<T, N> {
         self.elems.pop()
     }
 }
-
-impl<T, const N: usize> Drop for LocalVecIter<T, N> {
-    fn drop(&mut self) {
-        // we pay the price even if T doesn't implement Drop
-        let _ = self.last();
-    }
-}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -27,3 +27,35 @@ impl<T, const N: usize> Iterator for LocalVecIter<T, N> {
         self.elems.pop()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::LocalVec;
+
+    #[test]
+    fn test_iter() {
+        let vec = LocalVec::<_, 3>::from_array([1, 2, 3]);
+        let mut iter = vec.into_iter();
+        matches!(iter.next(), Some(1));
+        matches!(iter.next(), Some(2));
+        matches!(iter.next(), Some(3));
+        matches!(iter.next(), None);
+        matches!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_iter_empty() {
+        let vec = LocalVec::<usize, 2>::new();
+        let mut iter = vec.into_iter();
+        matches!(iter.next(), None);
+        matches!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_iter_zero_cap() {
+        let vec = LocalVec::<usize, 0>::new();
+        let mut iter = vec.into_iter();
+        matches!(iter.next(), None);
+        matches!(iter.next(), None);
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,59 +4,31 @@ use std::iter::{Iterator, IntoIterator};
 impl<T, const N: usize> IntoIterator for LocalVec<T, N> {
     type Item = T;
 
-    type IntoIter = LocalVecIter<T>;
+    type IntoIter = LocalVecIter<T, N>;
 
-    fn into_iter(self) -> LocalVecIter<T> {
-        // prevent the compiler from dropping the elements the vector
-        // was holding as the onwership must be handed over to the iterator
-        let this = std::mem::ManuallyDrop::new(self);
-
-        let begin = this.as_ptr();
-
-        // TODO what if T is a zero-sized type?
-        // SAFETY: one byte past the end of the same allocated object
-        let end = unsafe {
-            begin.add(this.len()) as *const T
-        };
-
-        LocalVecIter { 
-            ptr: begin,
-            end,
+    fn into_iter(self) -> LocalVecIter<T, N> {
+        let mut vec = self;
+        vec.reverse();
+        
+        LocalVecIter {
+            elems: vec,
         }
     }
 }
 
-pub struct LocalVecIter<T> {
-    ptr: *const T,
-    end: *const T,
+pub struct LocalVecIter<T, const N: usize> {
+    elems: LocalVec<T, N>,
 }
 
-impl<T> Iterator for LocalVecIter<T> {
+impl<T, const N: usize> Iterator for LocalVecIter<T, N> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
-        if self.ptr == self.end {
-            // end already reached
-            return None
-        }
-
-        // TODO
-        if std::mem::size_of::<T>() == 0 {
-            unimplemented!("zero-size types not yet supported")
-        }
-
-        let cur = self.ptr;
-        
-        // SAFETY: end not yet reached
-        self.ptr = unsafe {
-            self.ptr.offset(1)
-        };
-
-        Some(unsafe { std::ptr::read(cur) })
+        self.elems.pop()
     }
 }
 
-impl<T> Drop for LocalVecIter<T> {
+impl<T, const N: usize> Drop for LocalVecIter<T, N> {
     fn drop(&mut self) {
         // we pay the price even if T doesn't implement Drop
         let _ = self.last();

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,64 @@
+use crate::LocalVec;
+use std::iter::{Iterator, IntoIterator};
+
+impl<T, const N: usize> IntoIterator for LocalVec<T, N> {
+    type Item = T;
+
+    type IntoIter = LocalVecIter<T>;
+
+    fn into_iter(self) -> LocalVecIter<T> {
+        // prevent the compiler from dropping the elements the vector
+        // was holding as the onwership must be handed over to the iterator
+        let this = std::mem::ManuallyDrop::new(self);
+
+        let begin = this.as_ptr();
+
+        // TODO what if T is a zero-sized type?
+        // SAFETY: one byte past the end of the same allocated object
+        let end = unsafe {
+            begin.add(this.len()) as *const T
+        };
+
+        LocalVecIter { 
+            ptr: begin,
+            end,
+        }
+    }
+}
+
+pub struct LocalVecIter<T> {
+    ptr: *const T,
+    end: *const T,
+}
+
+impl<T> Iterator for LocalVecIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.ptr == self.end {
+            // end already reached
+            return None
+        }
+
+        // TODO
+        if std::mem::size_of::<T>() == 0 {
+            unimplemented!("zero-size types not yet supported")
+        }
+
+        let cur = self.ptr;
+        
+        // SAFETY: end not yet reached
+        self.ptr = unsafe {
+            self.ptr.offset(1)
+        };
+
+        Some(unsafe { std::ptr::read(cur) })
+    }
+}
+
+impl<T> Drop for LocalVecIter<T> {
+    fn drop(&mut self) {
+        // we pay the price even if T doesn't implement Drop
+        let _ = self.last();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod drop;
 mod index;
 mod from;
 mod deref;
+mod iter;
 
 #[derive(Debug)]
 /// A fixed-capacity vector that directly stores its elements  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod index;
 mod from;
 mod deref;
 mod iter;
+mod extend;
 
 #[derive(Debug)]
 /// A fixed-capacity vector that directly stores its elements  


### PR DESCRIPTION
So far, the crate provides only one of the usual three IntoIterator implementations: the implementation for consuming the collection and taking ownership of its elements. That is, the two following implementations of IntoIterator are missing:

  - For iterating over a shared reference to a LocalVec (i.e., for &LocalVec).
  - For iterating over a mutable reference to a LocalVec (i.e., for &mut LocalVec).
