### PR TITLE
Fix take_array unsoundness

### DIFF
--- a/src/drop.rs
+++ b/src/drop.rs
@@ -89,7 +89,7 @@ mod tests {
         buf.push(CounterGuard::new(&mut cnt));
         assert_eq!(cnt, 3);
 
-        let arr: [_; 3] = buf.into();
+        let arr: [CounterGuard; 3] = buf.try_into().unwrap();
         assert_eq!(cnt, 3);
 
         std::mem::drop(arr);
@@ -112,7 +112,7 @@ mod tests {
         buf.push(CounterGuard::new(&mut cnt));
         assert_eq!(cnt, 3);
 
-        let arr = buf.take_array();
+        let arr = unsafe { buf.take_array() };
         assert_eq!(buf.len(), 0);
         assert_eq!(cnt, 3);
 

--- a/src/from.rs
+++ b/src/from.rs
@@ -1,9 +1,33 @@
-use std::convert::From;
 use crate::LocalVec;
+use std::convert::{From, TryFrom};
+use std::mem::MaybeUninit;
 
-impl<T, const N: usize> From<LocalVec<T, N>> for [T; N] {
+impl<T, const N: usize> From<LocalVec<T, N>> for [MaybeUninit<T>; N] {
     fn from(mut local_vec: LocalVec<T, N>) -> Self {
-        local_vec.take_array()
+        local_vec.take_uninit_array()
+    }
+}
+
+#[derive(Debug)]
+pub struct NotFull;
+
+impl std::fmt::Display for NotFull {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("array is not full")
+    }
+}
+
+impl std::error::Error for NotFull {}
+
+impl<T, const N: usize> TryFrom<LocalVec<T, N>> for [T; N] {
+    type Error = NotFull;
+
+    fn try_from(mut local_vec: LocalVec<T, N>) -> Result<Self, Self::Error> {
+        if !local_vec.is_full() {
+            return Err(NotFull);
+        }
+        // Safety: checked for is_full before.
+        Ok(unsafe { local_vec.take_array() })
     }
 }
 
@@ -13,13 +37,13 @@ mod test {
 
     #[test]
     fn test_into_array() {
-        let mut vec = LocalVec::<_, 4>::new();
+        let mut vec = LocalVec::<u32, 4>::new();
         vec.push(0);
         vec.push(1);
         vec.push(2);
         vec.push(3);
 
-        let arr: [_; 4] = vec.into();
+        let arr: [u32; 4] = vec.try_into().unwrap();
         assert_eq!(arr[0], 0);
         assert_eq!(arr[1], 1);
         assert_eq!(arr[2], 2);


### PR DESCRIPTION
Hi there, thanks for your crate. I found an unsoundness bug, for instance this safe is an UB:

```rust
let mut v = LocalVecImpl::<_, 2>::new();
v.push(1);
v.take_array()[1]; // <- read uninitialized value
```

I propose to have two separate methods:
- `take_array() -> [T]` (with `assert!(self.is_full())`)
- `take_uninit_array() -> [MaybeUninit<T>]` (as trivial conversion)