### PR TITLE
Test drop with Rc

### DIFF
--- a/src/drop.rs
+++ b/src/drop.rs
@@ -10,113 +10,110 @@ impl <T, const N: usize> Drop for LocalVec<T, N> {
 
 #[cfg(test)]
 mod tests {
-    struct CounterGuard(*mut u8);
-
-    impl<'a> CounterGuard {
-        pub fn new(cnt: &'a mut u8) -> CounterGuard {
-            *cnt += 1;
-            CounterGuard(cnt as *mut u8)
-        }
-    }
-
-    impl<'a> Drop for CounterGuard {
-        fn drop(&mut self) {
-            unsafe {
-                *self.0 -= 1;
-            }
-        }
-    }
-
     use crate::LocalVec;
+    use std::rc::Rc;
+
+    #[derive(Clone)]
+    struct Counter(Rc<()>);
+
+    impl Counter {
+        fn new() -> Self {
+            Self(Rc::new(()))
+        }
+
+        fn count(&self) -> usize {
+            Rc::strong_count(&self.0)
+        }
+    }
 
     #[test]
     fn test_drop() {
-        let mut cnt = 0u8;
+        let cnt = Counter::new();
         let mut buf = LocalVec::<_, 3>::new();
 
-        assert_eq!(cnt, 0);
+        assert_eq!(cnt.count(), 1);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 1);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 2);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 2);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 3);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 3);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 4);
 
         std::mem::drop(buf);
-        assert_eq!(cnt, 0);
+        assert_eq!(cnt.count(), 1);
     }
 
     #[test]
     fn test_drop_after_set_len() {
-        let mut cnt = 0u8;
+        let cnt = Counter::new();
         let mut buf = LocalVec::<_, 3>::new();
 
-        assert_eq!(cnt, 0);
+        assert_eq!(cnt.count(), 1);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 1);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 2);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 2);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 3);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 3);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 4);
 
         unsafe {
             buf.set_len(1);
         }
 
         std::mem::drop(buf);
-        assert_eq!(cnt, 2);
+        assert_eq!(cnt.count(), 3);
     }
 
     #[test]
     fn test_drop_after_into_array() {
-        let mut cnt = 0u8;
+        let cnt = Counter::new();
         let mut buf = LocalVec::<_, 3>::new();
 
-        assert_eq!(cnt, 0);
+        assert_eq!(cnt.count(), 1);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 1);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 2);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 2);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 3);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 3);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 4);
 
-        let arr: [CounterGuard; 3] = buf.try_into().unwrap();
-        assert_eq!(cnt, 3);
+        let arr: [Counter; 3] = buf.try_into().unwrap();
+        assert_eq!(cnt.count(), 4);
 
         std::mem::drop(arr);
-        assert_eq!(cnt, 0);
+        assert_eq!(cnt.count(), 1);
     }
 
     #[test]
     fn test_drop_after_take_array() {
-        let mut cnt = 0u8;
+        let cnt = Counter::new();
         let mut buf = LocalVec::<_, 3>::new();
 
-        assert_eq!(cnt, 0);
+        assert_eq!(cnt.count(), 1);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 1);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 2);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 2);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 3);
 
-        buf.push(CounterGuard::new(&mut cnt));
-        assert_eq!(cnt, 3);
+        buf.push(cnt.clone());
+        assert_eq!(cnt.count(), 4);
 
         let arr = unsafe { buf.take_array() };
         assert_eq!(buf.len(), 0);
-        assert_eq!(cnt, 3);
+        assert_eq!(cnt.count(), 4);
 
         std::mem::drop(arr);
-        assert_eq!(cnt, 0);
+        assert_eq!(cnt.count(), 1);
     }
 }

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -89,7 +89,7 @@ mod tests {
         buf.push(CounterGuard::new(&mut cnt));
         assert_eq!(cnt, 3);
 
-        let arr: [_; 3] = buf.into();
+        let arr: [CounterGuard; 3] = buf.try_into().unwrap();
         assert_eq!(cnt, 3);
 
         std::mem::drop(arr);
@@ -112,7 +112,7 @@ mod tests {
         buf.push(CounterGuard::new(&mut cnt));
         assert_eq!(cnt, 3);
 
-        let arr = buf.take_array();
+        let arr = unsafe { buf.take_array() };
         assert_eq!(buf.len(), 0);
         assert_eq!(cnt, 3);
 

--- a/src/from.rs
+++ b/src/from.rs
@@ -1,9 +1,33 @@
-use std::convert::From;
 use crate::LocalVec;
+use std::convert::{From, TryFrom};
+use std::mem::MaybeUninit;
 
-impl<T, const N: usize> From<LocalVec<T, N>> for [T; N] {
+impl<T, const N: usize> From<LocalVec<T, N>> for [MaybeUninit<T>; N] {
     fn from(mut local_vec: LocalVec<T, N>) -> Self {
-        local_vec.take_array()
+        local_vec.take_uninit_array()
+    }
+}
+
+#[derive(Debug)]
+pub struct NotFull;
+
+impl std::fmt::Display for NotFull {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("array is not full")
+    }
+}
+
+impl std::error::Error for NotFull {}
+
+impl<T, const N: usize> TryFrom<LocalVec<T, N>> for [T; N] {
+    type Error = NotFull;
+
+    fn try_from(mut local_vec: LocalVec<T, N>) -> Result<Self, Self::Error> {
+        if !local_vec.is_full() {
+            return Err(NotFull);
+        }
+        // Safety: checked for is_full before.
+        Ok(unsafe { local_vec.take_array() })
     }
 }
 
@@ -13,13 +37,13 @@ mod test {
 
     #[test]
     fn test_into_array() {
-        let mut vec = LocalVec::<_, 4>::new();
+        let mut vec = LocalVec::<u32, 4>::new();
         vec.push(0);
         vec.push(1);
         vec.push(2);
         vec.push(3);
 
-        let arr: [_; 4] = vec.into();
+        let arr: [u32; 4] = vec.try_into().unwrap();
         assert_eq!(arr[0], 0);
         assert_eq!(arr[1], 1);
         assert_eq!(arr[2], 2);


### PR DESCRIPTION
`CounterGuard` type is generally unsound (it might lead to a dangling ref). Although I'm not sure there's an UB now but better be safe and use well-tested standard type (`Rc`) for this job.

Note, the PR includes patch from the #14 so no need to rebase. This one shall be merged after the linked one.